### PR TITLE
[/device/auth] Make authenticate_device return None in case of failure

### DIFF
--- a/LBS/main/auth/auth_provider.py
+++ b/LBS/main/auth/auth_provider.py
@@ -14,10 +14,7 @@ def authenticate_device(device, serial):
             "roles": ["user"],
         }
     else:
-        return {
-            "status": "fail",
-            "message": "Device not found",
-        }
+        return None
 
 
 def authenticate_admin(user_name, password):

--- a/LBS/main/auth/auth_provider.py
+++ b/LBS/main/auth/auth_provider.py
@@ -25,4 +25,4 @@ def authenticate_admin(user_name, password):
             "roles": ["admin", "user"],
         }
     else:
-        return {"status": "fail", "message": "User does not exist"}
+        return None

--- a/LBS/main/service/admin_service.py
+++ b/LBS/main/service/admin_service.py
@@ -23,7 +23,6 @@ def create_admin(data):
 
 
 def auth_admin_service(data):
-    print(data["user_name"])
     user_name = data["user_name"]
     password = data["password"]
     if not user_name or not password:


### PR DESCRIPTION
There is a problem with `jwt.encode` function here. Sometimes I get following error, when the line is executed:

```
  File "/LBS/main/service/device_service.py", line 37, in auth_device_service
    token = generate_jwt(
            ^^^^^^^^^^^^^
  File "/LBS/main/auth/jwt_handler.py", line 11, in generate_jwt
    return jwt.encode(payload, getenv("SECRET_KEY"), algorithm="HS256")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.cache/pypoetry/virtualenvs/lbs_server-jswDA9Zo-py3.12/lib/python3.12/site-packages/jwt/api_jwt.py", line 73, in encode
    return api_jws.encode(
           ^^^^^^^^^^^^^^^
  File "/root/.cache/pypoetry/virtualenvs/lbs_server-jswDA9Zo-py3.12/lib/python3.12/site-packages/jwt/api_jws.py", line 160, in encode
    key = alg_obj.prepare_key(key)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.cache/pypoetry/virtualenvs/lbs_server-jswDA9Zo-py3.12/lib/python3.12/site-packages/jwt/algorithms.py", line 265, in prepare_key
    key_bytes = force_bytes(key)
                ^^^^^^^^^^^^^^^^
  File "/root/.cache/pypoetry/virtualenvs/lbs_server-jswDA9Zo-py3.12/lib/python3.12/site-packages/jwt/utils.py", line 22, in force_bytes
    raise TypeError("Expected a string value")
TypeError: Expected a string value
172.19.0.1 - - [11/Jun/2024 18:03:38] "POST /device/auth HTTP/1.1" 500 -
```

After this change there is no error. I couldn't understand, how does this function work.